### PR TITLE
[issue#001]: fix problem with bubbles

### DIFF
--- a/src/views/Chat.js
+++ b/src/views/Chat.js
@@ -45,7 +45,7 @@ export function Example({ route }) {
         renderTime={() => null}
         onSend={(message) => onSend(message)}
         user={{
-          id: "184f7251-7688-4ea1-83ba-1d857ab6e4e3",
+          _id: "184f7251-7688-4ea1-83ba-1d857ab6e4e3",
         }}
       />
     </>


### PR DESCRIPTION
Fix problems with bubbles described in issue #3 

1. wrongly passed argument in gifted chat as user:

`user={{ id: 'some id here'}}  >> user={{ _id: 'some id here'}}`